### PR TITLE
feat(api): validate URL in register function and add corresponding tests

### DIFF
--- a/src/utils/api/register.ts
+++ b/src/utils/api/register.ts
@@ -79,6 +79,17 @@ export async function register(card: AgentCard): Promise<string> {
     return "";
   }
 
+  if (
+    card.url === undefined ||
+    card.url === null ||
+    card.url === "" ||
+    card.url.includes("localhost") ||
+    card.url.includes("127.0.0.1")
+  ) {
+    logDebug("A2AServer", "Invalid URL provided", card.url);
+    return "";
+  }
+
   try {
     const registration = convert(card);
     logInfo("A2AServer", "Registration", registration);

--- a/tests/register.test.ts
+++ b/tests/register.test.ts
@@ -30,7 +30,7 @@ describe("register Function", () => {
     sampleAgentCard = {
       name: "Test Agent",
       description: "A test agent card",
-      url: "http://localhost:8080/agent",
+      url: "https://agents.artinet.io/agent",
       version: "1.0.0",
       capabilities: {
         streaming: false,
@@ -136,5 +136,20 @@ describe("register Function", () => {
     } as Response);
     await register(sampleAgentCard);
     expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+  test("should return empty string if URL is localhost", async () => {
+    sampleAgentCard.url = "http://localhost:8080/agent";
+    const result = await register(sampleAgentCard);
+    expect(result).toBe("");
+  });
+  test("should return empty string if URL is 127.0.0.1", async () => {
+    sampleAgentCard.url = "http://127.0.0.1:8080/agent";
+    const result = await register(sampleAgentCard);
+    expect(result).toBe("");
+  });
+  test("should return empty string if URL is empty", async () => {
+    sampleAgentCard.url = "";
+    const result = await register(sampleAgentCard);
+    expect(result).toBe("");
   });
 });


### PR DESCRIPTION
- Added validation to the register function to return an empty string for invalid URLs (localhost, 127.0.0.1, or empty).
- Implemented unit tests to ensure the register function behaves correctly with invalid URLs.