### PR TITLE
Refactor transform.ts and context.ts for improved code clarity

### DIFF
--- a/src/types/services/context.ts
+++ b/src/types/services/context.ts
@@ -191,22 +191,22 @@ export const executionContextConfig = {
 } as const;
 
 //todo move to utils
-export function getParams(context: ExecutionContext) {
-  console.log("getParams", context);
-  switch (context.protocol) {
-    case Protocol.A2A:
-      const a2aRequestParams = context.getRequestParams();
-      if (!a2aRequestParams) {
-        throw new Error("No request params provided");
-      }
-      return a2aRequestParams;
-    case Protocol.MCP:
-      const mcpRequestParams = context.getRequestParams();
-      if (!mcpRequestParams) {
-        throw new Error("No request params provided");
-      }
-      return mcpRequestParams;
-    default:
-      throw new Error("Invalid protocol");
-  }
-}
+// export function getParams(context: ExecutionContext) {
+//   console.log("getParams", context);
+//   switch (context.protocol) {
+//     case Protocol.A2A:
+//       const a2aRequestParams = context.getRequestParams();
+//       if (!a2aRequestParams) {
+//         throw new Error("No request params provided");
+//       }
+//       return a2aRequestParams;
+//     case Protocol.MCP:
+//       const mcpRequestParams = context.getRequestParams();
+//       if (!mcpRequestParams) {
+//         throw new Error("No request params provided");
+//       }
+//       return mcpRequestParams;
+//     default:
+//       throw new Error("Invalid protocol");
+//   }
+// }

--- a/src/types/transform.ts
+++ b/src/types/transform.ts
@@ -85,6 +85,7 @@ export function createRenameConfig<T extends object>() {
 /**
  * Common transformation patterns using built-in utility types
  */
+// eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace TransformPatterns {
   /**
    * Convert snake_case keys to camelCase


### PR DESCRIPTION
- Added an ESLint directive to suppress warnings for the TransformPatterns namespace in transform.ts.
- Commented out the getParams function in context.ts to indicate it is deprecated and will be moved to utils for better organization.