### PR TITLE
New import option and refactor of TaskManager for Agent Execution

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+.gitignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Updated `zod` package version
   - **BREAKING**: Rolled back from `zod/v4` to standard `zod` for better compatibility
 - Improved service interface architecture to support multiple protocol bindings
+- Renamed `artinet.v0.taskManager` and it's associate type `TaskManager` to `artinet.v0.agentExecutor` and `AgentExecutor` to avoid confusion with A2A `TaskManager` in `service.ts`
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ It has [serveral template projects](https://github.com/the-artinet-project/creat
 | **Transport Layers** | Built-in support for Express/TRPC.                                          | Express middleware, tRPC router, or easily create your own.                                          |
 | **Core Types**       | Fully implement A2A schema in Zod.                                          | `AgentCard`, `Task`, `Message`, `Part`, `Artifact`, etc.                                             |
 | **Deployment**       | Bundle, test, and deploy agents onto the artinet platform (v0.5.2).         | `@artinet/sdk/deployment`, `fullDeployment`, `testDeployment`, `bundle`                              |
-| **Agent Utilities**  | Run agents in managed environments with our proxy system.                   | `artinet.v0.taskManager`, `artinet.v0.connect`, `artinet.v0.agent`                                   |
+| **Agent Utilities**  | Run agents in managed environments with our proxy system.                   | `artinet.v0.agentExecutor`, `artinet.v0.connect`, `artinet.v0.agent`                                   |
 
 ## Installation
 
@@ -781,7 +781,7 @@ Key features include:
 
 - **Sandboxed Enviroments:** Streamline agent logic for quick and easy deployments. The new `artinet.v0` namespace (accessible via `@artinet/sdk/agents`) provides `taskManager`, `connect`, and `agent`.
 
-  - `artinet.v0.taskManager`: Manages the agent's lifecycle by iterating over the agent's `TaskHandler` and communicating updates to the host environment.
+  - `artinet.v0.agentExecutor`: Manages the agent's lifecycle by iterating over the agent's `TaskHandler` and communicating updates to the host environment.
   - `artinet.v0.connect`: Replaces the deprecated `fetchResponseProxy`. Allows agents to make proxied calls to other agents or LLMs via the host environment.
   - `artinet.v0.agent`: A factory function to obtain a `ClientProxy` for type-safe communication with other agents, managed by the host environment.
 
@@ -811,10 +811,10 @@ Key features include:
   }
 
   // The host environment will invoke this taskManager with the agent's logic.
-  await artinet.v0.taskManager({ taskHandler: myAgentLogic });
+  await artinet.v0.agentExecutor({ taskHandler: myAgentLogic });
   ```
 
-  _Note: The `taskHandlerProxy` and `fetchResponseProxy` utilities are now deprecated in favor of `artinet.v0.taskManager` and `artinet.v0.connect` respectively._
+  _Note: The `taskHandlerProxy` and `fetchResponseProxy` utilities are now deprecated in favor of `artinet.v0.agentExecutor` and `artinet.v0.connect` respectively._
 
 - **Test-Agents (Experimental):** Simulate and test your agents @ agents.artinet.io/test/deploy using the `testDeployment` tool.
 

--- a/examples/code-deployment.ts
+++ b/examples/code-deployment.ts
@@ -86,5 +86,5 @@ export const coderAgent: AgentEngine = async function* (context: Context) {
   yield finalUpdate;
 };
 
-await artinet.v0.taskManager({ taskHandler: coderAgent });
+await artinet.v0.agentExecutor({ taskHandler: coderAgent });
 console.log("[CoderAgent] Finished");

--- a/examples/nested-deployment.ts
+++ b/examples/nested-deployment.ts
@@ -165,5 +165,5 @@ export const simpleEchoAgent: AgentEngine = async function* (context: Context) {
   yield completedUpdate;
 };
 
-await artinet.v0.taskManager({ taskHandler: simpleEchoAgent });
+await artinet.v0.agentExecutor({ taskHandler: simpleEchoAgent });
 console.log("[SimpleEchoAgent] Finished");

--- a/llms.txt
+++ b/llms.txt
@@ -67,7 +67,7 @@ The SDK is distributed as the `@artinet/sdk` npm package (current version: 0.5.6
     *   Supports dynamic agent creation and management with shared state.
 
 *   **Code Deployment & Management:**
-    *   **`artinet.v0.taskManager`**: Standard utility for agents in managed environments to interact with the host for task lifecycle management.
+    *   **`artinet.v0.agentExecutor`**: Standard utility for agents in managed environments to interact with the host for task lifecycle management.
     *   **`artinet.v0.connect`**: Standard utility for agents in managed environments to make proxied calls to other agents or LLMs.
     *   **`artinet.v0.agent`**: Factory function for agents in managed environments to obtain a `ClientProxy` for type-safe communication.
     *   `bundler`: Utility to bundle agent code using `esbuild`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artinet/sdk",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "TypeScript SDK for the Agent2Agent (A2A) Protocol",
   "type": "module",
   "main": "./dist/index.js",
@@ -21,6 +21,12 @@
       "types": "./dist/types/utils/deployment/index.d.ts",
       "import": "./dist/utils/deployment/index.js",
       "default": "./dist/utils/deployment/index.js"
+    },
+    "./types":
+    {
+      "types": "./dist/types/types/index.d.ts",
+      "import": "./dist/types/index.js",
+      "default": "./dist/types/index.js"
     }
   },
   "rootDir": ".",

--- a/src/types/schemas/deployment/proxy.ts
+++ b/src/types/schemas/deployment/proxy.ts
@@ -37,7 +37,7 @@ export interface TaskManagerProps {
  * @param props - The properties for the task manager, including the taskHandler.
  * @returns A promise that resolves when the task handler has completed.
  */
-export type TaskManager = (props: TaskManagerProps) => Promise<void>;
+export type AgentExecutor = (props: TaskManagerProps) => Promise<void>;
 
 /**
  * Properties for the Connect function.

--- a/src/types/schemas/index.ts
+++ b/src/types/schemas/index.ts
@@ -1,2 +1,2 @@
 export * from "./a2a/index.js";
-// export * from "./deployment/index.js";
+export * from "./deployment/index.js";

--- a/src/utils/deployment/agents.ts
+++ b/src/utils/deployment/agents.ts
@@ -9,7 +9,7 @@ import {
   ClientProxy,
   ConnectAPICallback,
   ConnectProps,
-  TaskManager,
+  AgentExecutor,
   TaskManagerProps,
   TaskProxy,
 } from "~/types/schemas/deployment/index.js";
@@ -38,7 +38,7 @@ export namespace artinet {
      * @throws An error if the `taskManagerStub` or `context` is not set in `process.env`,
      *         indicating an invalid runtime environment.
      */
-    export const taskManager: TaskManager = async (props: TaskManagerProps) => {
+    export const agentExecutor: AgentExecutor = async (props: TaskManagerProps) => {
       const { taskHandler } = props;
       if (!env.taskManagerStub && !env.context) {
         console.warn(

--- a/src/utils/deployment/task-wrapper.ts
+++ b/src/utils/deployment/task-wrapper.ts
@@ -21,14 +21,14 @@ import { artinet } from "./agents.js";
  * made available in the `env` by the host environment.
  *
  * The `Context` (ExecutionContext) is also expected to be provided by the host environment via `env`.
- * @deprecated This function is deprecated and will be removed in a future version. Use the `Artinet.v0.taskManager` function instead.
+ * @deprecated This function is deprecated and will be removed in a future version. Use the `artinet.v0.agentExecutor` function instead.
  * @param taskHandler - An asynchronous generator function that takes a `ExecutionContext`
  *                      and yields `UpdateEvent` objects, eventually returning a `Task` or void.
  * @throws An error if the required `env.hostOnYield` or `env.Context` are not found,
  *         indicating an invalid runtime environment.
  */
 export const taskHandlerProxy = async (taskHandler: AgentEngine) => {
-  return await artinet.v0.taskManager({ taskHandler });
+  return await artinet.v0.agentExecutor({ taskHandler });
 };
 
 /**

--- a/src/utils/logging/logger.ts
+++ b/src/utils/logging/logger.ts
@@ -6,7 +6,7 @@
 /**
  * Logger utility for the SDK using Pino
  */
-import { pino } from "pino";
+import pino from "pino";
 
 // Define log levels for type safety
 export type LogLevel = "silent" | "error" | "warn" | "info" | "debug" | "trace";


### PR DESCRIPTION
Changes:
- Cleaner type import for easier use
- Allow import of agent executor/rename to avoid clash with TaskManager updates in 0.5.6 release
- Bump version number that wasnt bumped before